### PR TITLE
Fix #9: update guest code for current `nssa_core` program API

### DIFF
--- a/lez-rln/methods/guest/src/bin/incremental_merkle_tree.rs
+++ b/lez-rln/methods/guest/src/bin/incremental_merkle_tree.rs
@@ -16,7 +16,7 @@ use nssa_core::program::{ProgramInput, ProgramOutput, read_nssa_inputs};
 type Instruction = Vec<u8>;
 
 fn main() {
-    let (ProgramInput { self_program_id, pre_states, instruction }, instruction_words) =
+    let (ProgramInput { pre_states, instruction }, instruction_words) =
         read_nssa_inputs::<Instruction>();
 
     let post_states = match instruction[0] {
@@ -30,5 +30,5 @@ fn main() {
         _ => panic!("Invalid instruction type"),
     };
 
-    ProgramOutput::new(self_program_id, instruction_words, pre_states, post_states).write();
+    ProgramOutput::new(instruction_words, pre_states, post_states).write();
 }

--- a/lez-rln/methods/guest/src/bin/incremental_merkle_tree.rs
+++ b/lez-rln/methods/guest/src/bin/incremental_merkle_tree.rs
@@ -16,13 +16,8 @@ use nssa_core::program::{ProgramInput, ProgramOutput, read_nssa_inputs};
 type Instruction = Vec<u8>;
 
 fn main() {
-    let (
-        ProgramInput {
-            pre_states,
-            instruction,
-        },
-        instruction_words,
-    ) = read_nssa_inputs::<Instruction>();
+    let (ProgramInput { self_program_id, pre_states, instruction }, instruction_words) =
+        read_nssa_inputs::<Instruction>();
 
     let post_states = match instruction[0] {
         0 => initialize_tree(pre_states.clone()),
@@ -35,5 +30,5 @@ fn main() {
         _ => panic!("Invalid instruction type"),
     };
 
-    ProgramOutput::new(instruction_words, pre_states, post_states).write();
+    ProgramOutput::new(self_program_id, instruction_words, pre_states, post_states).write();
 }

--- a/lez-rln/methods/guest/src/bin/rln_registration.rs
+++ b/lez-rln/methods/guest/src/bin/rln_registration.rs
@@ -71,7 +71,7 @@ use nssa_core::{
 };
 
 fn main() {
-    let (ProgramInput { self_program_id, pre_states, instruction }, instruction_data) =
+    let (ProgramInput { pre_states, instruction }, instruction_data) =
         read_nssa_inputs::<Instruction>();
 
     match instruction {
@@ -84,7 +84,6 @@ fn main() {
                 registration_program_id, merkle_program_id, tree_id,
                 payment_token_id, price_per_unit, treasury_account_id,
                 token_program_id, max_total_rate_limit,
-                self_program_id,
                 instruction_data,
             )
         }
@@ -94,7 +93,6 @@ fn main() {
                 registration_program_id, id_commitment, rate_limit,
                 &pre_states[0], &pre_states[1], &pre_states[2], &pre_states[3],
                 &pre_states[4],
-                self_program_id,
                 instruction_data,
             )
         }
@@ -104,7 +102,6 @@ fn main() {
                 amount,
                 &pre_states[0], &pre_states[1], &pre_states[2],
                 &pre_states[3], &pre_states[4],
-                self_program_id,
                 instruction_data,
             )
         }
@@ -116,7 +113,6 @@ fn main() {
                 registration_program_id, id_commitment, amount_to_burn,
                 &pre_states[0], &pre_states[1], &pre_states[2], &pre_states[3],
                 &pre_states[4],
-                self_program_id,
                 instruction_data,
             )
         }
@@ -125,7 +121,6 @@ fn main() {
             slash(
                 identity_secret,
                 &pre_states[0], &pre_states[1], &pre_states[2], &pre_states[3],
-                self_program_id,
                 instruction_data,
             )
         }
@@ -145,7 +140,6 @@ fn initialize(
     treasury_account_id: [u8; 32],
     token_program_id: [u8; 32],
     max_total_rate_limit: u64,
-    self_program_id: ProgramId,
     instruction_data: Vec<u32>,
 ) {
     assert!(max_total_rate_limit > 0, "Max total rate limit must be positive");
@@ -220,12 +214,7 @@ fn initialize(
         AccountPostState::new(Account::default()),
         AccountPostState::new(Account::default()),
     ];
-    ProgramOutput::new(
-        self_program_id,
-        instruction_data,
-        output_pre_states,
-        post_states,
-    )
+    ProgramOutput::new(instruction_data, output_pre_states, post_states)
     .with_chained_calls(vec![token_create_call, merkle_chained_call])
     .write();
 }
@@ -239,7 +228,6 @@ fn register(
     user_holding: &AccountWithMetadata,
     treasury_holding: &AccountWithMetadata,
     bottom_subtree: &AccountWithMetadata,
-    self_program_id: ProgramId,
     instruction_data: Vec<u32>,
 ) {
     validate_rate_limit(rate_limit);
@@ -318,12 +306,7 @@ fn register(
         AccountPostState::new_claimed_if_default(membership_post, Claim::Pda(membership_seed)),
     ];
 
-    ProgramOutput::new(
-        self_program_id,
-        instruction_data,
-        output_pre_states,
-        post_states,
-    )
+    ProgramOutput::new(instruction_data, output_pre_states, post_states)
     .with_chained_calls(vec![token_call, merkle_call])
     .write();
 }
@@ -335,7 +318,6 @@ fn buy_credits(
     user_payment_holding: &AccountWithMetadata,
     treasury_holding: &AccountWithMetadata,
     user_credit_holding: &AccountWithMetadata,
-    self_program_id: ProgramId,
     instruction_data: Vec<u32>,
 ) {
 
@@ -387,12 +369,7 @@ fn buy_credits(
         user_credit_holding.clone(),
     ];
 
-    ProgramOutput::new(
-        self_program_id,
-        instruction_data,
-        output_pre_states,
-        post_states,
-    )
+    ProgramOutput::new(instruction_data, output_pre_states, post_states)
     .with_chained_calls(vec![transfer_call, mint_call])
     .write();
 }
@@ -406,7 +383,6 @@ fn register_with_credits(
     tree_main: &AccountWithMetadata,
     user_credit_holding: &AccountWithMetadata,
     bottom_subtree: &AccountWithMetadata,
-    self_program_id: ProgramId,
     instruction_data: Vec<u32>,
 ) {
 
@@ -485,12 +461,7 @@ fn register_with_credits(
         AccountPostState::new_claimed_if_default(membership_post, Claim::Pda(membership_seed)),
     ];
 
-    ProgramOutput::new(
-        self_program_id,
-        instruction_data,
-        output_pre_states,
-        post_states,
-    )
+    ProgramOutput::new(instruction_data, output_pre_states, post_states)
     .with_chained_calls(vec![burn_call, merkle_call])
     .write();
 }
@@ -501,7 +472,6 @@ fn slash(
     tree_main: &AccountWithMetadata,
     membership_account: &AccountWithMetadata,
     bottom_subtree: &AccountWithMetadata,
-    self_program_id: ProgramId,
     instruction_data: Vec<u32>,
 ) {
 
@@ -547,12 +517,7 @@ fn slash(
         AccountPostState::new(bottom_subtree.account.clone()),
     ];
 
-    ProgramOutput::new(
-        self_program_id,
-        instruction_data,
-        output_pre_states,
-        post_states,
-    )
+    ProgramOutput::new(instruction_data, output_pre_states, post_states)
     .with_chained_calls(vec![merkle_call])
     .write();
 }

--- a/lez-rln/methods/guest/src/bin/rln_registration.rs
+++ b/lez-rln/methods/guest/src/bin/rln_registration.rs
@@ -71,7 +71,7 @@ use nssa_core::{
 };
 
 fn main() {
-    let (ProgramInput { pre_states, instruction }, instruction_data) =
+    let (ProgramInput { self_program_id, pre_states, instruction }, instruction_data) =
         read_nssa_inputs::<Instruction>();
 
     match instruction {
@@ -84,6 +84,7 @@ fn main() {
                 registration_program_id, merkle_program_id, tree_id,
                 payment_token_id, price_per_unit, treasury_account_id,
                 token_program_id, max_total_rate_limit,
+                self_program_id,
                 instruction_data,
             )
         }
@@ -93,6 +94,7 @@ fn main() {
                 registration_program_id, id_commitment, rate_limit,
                 &pre_states[0], &pre_states[1], &pre_states[2], &pre_states[3],
                 &pre_states[4],
+                self_program_id,
                 instruction_data,
             )
         }
@@ -102,6 +104,7 @@ fn main() {
                 amount,
                 &pre_states[0], &pre_states[1], &pre_states[2],
                 &pre_states[3], &pre_states[4],
+                self_program_id,
                 instruction_data,
             )
         }
@@ -113,6 +116,7 @@ fn main() {
                 registration_program_id, id_commitment, amount_to_burn,
                 &pre_states[0], &pre_states[1], &pre_states[2], &pre_states[3],
                 &pre_states[4],
+                self_program_id,
                 instruction_data,
             )
         }
@@ -121,6 +125,7 @@ fn main() {
             slash(
                 identity_secret,
                 &pre_states[0], &pre_states[1], &pre_states[2], &pre_states[3],
+                self_program_id,
                 instruction_data,
             )
         }
@@ -140,6 +145,7 @@ fn initialize(
     treasury_account_id: [u8; 32],
     token_program_id: [u8; 32],
     max_total_rate_limit: u64,
+    self_program_id: ProgramId,
     instruction_data: Vec<u32>,
 ) {
     assert!(max_total_rate_limit > 0, "Max total rate limit must be positive");
@@ -214,9 +220,14 @@ fn initialize(
         AccountPostState::new(Account::default()),
         AccountPostState::new(Account::default()),
     ];
-    ProgramOutput::new(instruction_data, output_pre_states, post_states)
-        .with_chained_calls(vec![token_create_call, merkle_chained_call])
-        .write();
+    ProgramOutput::new(
+        self_program_id,
+        instruction_data,
+        output_pre_states,
+        post_states,
+    )
+    .with_chained_calls(vec![token_create_call, merkle_chained_call])
+    .write();
 }
 
 fn register(
@@ -228,6 +239,7 @@ fn register(
     user_holding: &AccountWithMetadata,
     treasury_holding: &AccountWithMetadata,
     bottom_subtree: &AccountWithMetadata,
+    self_program_id: ProgramId,
     instruction_data: Vec<u32>,
 ) {
     validate_rate_limit(rate_limit);
@@ -306,9 +318,14 @@ fn register(
         AccountPostState::new_claimed_if_default(membership_post, Claim::Pda(membership_seed)),
     ];
 
-    ProgramOutput::new(instruction_data, output_pre_states, post_states)
-        .with_chained_calls(vec![token_call, merkle_call])
-        .write();
+    ProgramOutput::new(
+        self_program_id,
+        instruction_data,
+        output_pre_states,
+        post_states,
+    )
+    .with_chained_calls(vec![token_call, merkle_call])
+    .write();
 }
 
 fn buy_credits(
@@ -318,6 +335,7 @@ fn buy_credits(
     user_payment_holding: &AccountWithMetadata,
     treasury_holding: &AccountWithMetadata,
     user_credit_holding: &AccountWithMetadata,
+    self_program_id: ProgramId,
     instruction_data: Vec<u32>,
 ) {
 
@@ -369,9 +387,14 @@ fn buy_credits(
         user_credit_holding.clone(),
     ];
 
-    ProgramOutput::new(instruction_data, output_pre_states, post_states)
-        .with_chained_calls(vec![transfer_call, mint_call])
-        .write();
+    ProgramOutput::new(
+        self_program_id,
+        instruction_data,
+        output_pre_states,
+        post_states,
+    )
+    .with_chained_calls(vec![transfer_call, mint_call])
+    .write();
 }
 
 fn register_with_credits(
@@ -383,6 +406,7 @@ fn register_with_credits(
     tree_main: &AccountWithMetadata,
     user_credit_holding: &AccountWithMetadata,
     bottom_subtree: &AccountWithMetadata,
+    self_program_id: ProgramId,
     instruction_data: Vec<u32>,
 ) {
 
@@ -461,9 +485,14 @@ fn register_with_credits(
         AccountPostState::new_claimed_if_default(membership_post, Claim::Pda(membership_seed)),
     ];
 
-    ProgramOutput::new(instruction_data, output_pre_states, post_states)
-        .with_chained_calls(vec![burn_call, merkle_call])
-        .write();
+    ProgramOutput::new(
+        self_program_id,
+        instruction_data,
+        output_pre_states,
+        post_states,
+    )
+    .with_chained_calls(vec![burn_call, merkle_call])
+    .write();
 }
 
 fn slash(
@@ -472,6 +501,7 @@ fn slash(
     tree_main: &AccountWithMetadata,
     membership_account: &AccountWithMetadata,
     bottom_subtree: &AccountWithMetadata,
+    self_program_id: ProgramId,
     instruction_data: Vec<u32>,
 ) {
 
@@ -517,7 +547,12 @@ fn slash(
         AccountPostState::new(bottom_subtree.account.clone()),
     ];
 
-    ProgramOutput::new(instruction_data, output_pre_states, post_states)
-        .with_chained_calls(vec![merkle_call])
-        .write();
+    ProgramOutput::new(
+        self_program_id,
+        instruction_data,
+        output_pre_states,
+        post_states,
+    )
+    .with_chained_calls(vec![merkle_call])
+    .write();
 }

--- a/lez-rln/methods/guest/src/merkle_tree.rs
+++ b/lez-rln/methods/guest/src/merkle_tree.rs
@@ -28,7 +28,7 @@
 
 use crate::hash::{ZERO, compute_default_hashes, hash_pair};
 use nssa_core::account::AccountWithMetadata;
-use nssa_core::program::{AccountPostState, Claim, PdaSeed};
+use nssa_core::program::{AccountPostState, Claim};
 pub use rln_layouts::{
     TREE_DEPTH, TOP_DEPTH, BOTTOM_DEPTH, SUBTREE_LEAVES,
     OFFSET_DEPTH, OFFSET_NEXT_INDEX, OFFSET_ROOT, OFFSET_ROOT_HISTORY, ROOT_HISTORY_SIZE,


### PR DESCRIPTION
## Description

This PR updates the guest code to match the current `nssa_core` program API.

Changes:

- add explicit `Claim` arguments to `AccountPostState::new_claimed_if_default(...)`
- use `Claim::Authorized` in the merkle guest code
- use `Claim::Pda(...)` for registration-owned PDA accounts
- replace removed output helper functions with `ProgramOutput::new(...).with_chained_calls(...).write()`
- update `ProgramInput` destructuring to include `self_program_id`

Testing:

```text
RUSTC_BOOTSTRAP=1 cargo test -p logos_lez_rln_guest
```

Result:

- `43 passed, 0 failed`
- guest binary targets built and passed
- doc tests passed