### PR TITLE
feat: registration via membership allocation protocol using keycard

### DIFF
--- a/logos-rln-membership-module/rust-lib/src/lib.rs
+++ b/logos-rln-membership-module/rust-lib/src/lib.rs
@@ -276,6 +276,19 @@ fn register_impl(
     let pm = prov.get_membership(&registry, &credential.identity_commitment)?;
     if pm.registered {
         let mismatch = pm.rate_limit != rate_limit;
+        // A gifter-registered membership was submitted by the gifter, not us, so
+        // there's no register_member reply to record. If the caller passes the
+        // gifter's tx hash (options_json.gifter_tx_hash), synthesize the same
+        // tx_result envelope public_membership_json expects so the detail view
+        // shows the transaction like a wallet-path registration.
+        let gifter_tx_result: Option<String> = serde_json::from_str::<serde_json::Value>(options_json)
+            .ok()
+            .and_then(|o| o.get("gifter_tx_hash").and_then(|x| x.as_str()).map(String::from))
+            .filter(|s| !s.is_empty())
+            .map(|tx| {
+                let inner = serde_json::json!({"error": "", "secrets": [], "success": true, "tx_hash": tx}).to_string();
+                serde_json::json!({"tx_result": inner}).to_string()
+            });
         store::with_store(|s| {
             if s.get(&hash).is_some() {
                 s.update(&hash, |m| {
@@ -283,6 +296,9 @@ fn register_impl(
                     m.leaf_index = pm.leaf_index;
                     m.rate_limit = pm.rate_limit;
                     m.failed_reason = None;
+                    if m.tx_result.is_none() {
+                        m.tx_result = gifter_tx_result.clone();
+                    }
                 })
             } else {
                 let meta = store::MembershipMeta {
@@ -294,7 +310,7 @@ fn register_impl(
                     state: pm.state.clone(),
                     state_history: vec![],
                     submitted_at: now_unix(),
-                    tx_result: None,
+                    tx_result: gifter_tx_result.clone(),
                 };
                 s.insert(&hash, meta, &credential)
             }

--- a/logos-rln-membership-ui/metadata.json
+++ b/logos-rln-membership-ui/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "rln_membership_ui",
   "display_name": "RLN Membership",
-  "version": "0.3.1",
+  "version": "0.6.0",
   "type": "ui_qml",
   "category": "blockchain",
   "description": "RLN membership GUI: guided onboarding wizard, membership status card, and an advanced expert view (drives liblogos_rln_membership_module)",
@@ -11,7 +11,10 @@
   "dependencies": [
     "logos_execution_zone",
     "liblogos_rln_membership_module",
-    "liblogos_rln_module"
+    "liblogos_rln_module",
+    "libp2p_module",
+    "rln_gifter_module",
+    "keycard_capture_module"
   ],
   "nix": {
     "packages": {

--- a/logos-rln-membership-ui/qml/MembershipCard.qml
+++ b/logos-rln-membership-ui/qml/MembershipCard.qml
@@ -61,7 +61,12 @@ Item {
             return
         refreshing = true
         flow.callRetry(M.MEMBERSHIP_MODULE, "get_memberships", [registryId], function (r) {
-            if (r.error) { card.error = M.errorText(r.error); card.refreshing = false; return }
+            if (r.error) {
+                // Transient hiccup: keep the card as-is, retry next tick.
+                if (!M.isTransientError(r.error.kind)) card.error = M.errorText(r.error)
+                card.refreshing = false
+                return
+            }
             card.error = ""
             var rows = r.memberships || []
             var row = null

--- a/logos-rln-membership-ui/qml/MembershipView.qml
+++ b/logos-rln-membership-ui/qml/MembershipView.qml
@@ -59,7 +59,13 @@ Item {
         completionRefresh = false
         flow.callRetry(M.MEMBERSHIP_MODULE, "get_memberships", [registryId], function (r) {
             view.refreshing = false
-            if (r.error) { view.error = M.errorText(r.error); return }
+            if (r.error) {
+                // A transient poll hiccup (bridge/module timeout, e.g. a slow
+                // on-chain read) must NOT replace the shown memberships with an
+                // error — keep the last-known list and let the next tick retry.
+                if (!M.isTransientError(r.error.kind)) view.error = M.errorText(r.error)
+                return
+            }
             view.error = ""
             var list = (r.memberships || []).map(function (m) {
                 return {

--- a/logos-rln-membership-ui/qml/OnboardingFlow.qml
+++ b/logos-rln-membership-ui/qml/OnboardingFlow.qml
@@ -110,6 +110,47 @@ Item {
     // register, which hands it to the module's encrypted keystore.
     property string secretHash: ""
 
+    // ---- Gifter path (alternative to Phases A/B/D) -------------------------
+    // "gifter" replaces wallet-provision + sync + faucet with a libp2p dial to
+    // a gifter node that pays for the registration, authorized by a Keycard
+    // attestation. Phase C (keystore unlock) and the Phase E register+poll tail
+    // are REUSED — the gifter registers the identity on-chain, then the
+    // idempotent register() records it in the keystore with no funds. Set on
+    // Welcome; reset to "wallet" by resetForNewRegistration.
+    property string registrationMode: "wallet"
+    // idle | running | done | error. gifterStage is the running sub-step, for
+    // the progress caption: node -> identity -> capture -> dial -> persist.
+    property string gifterPhase: "idle"
+    property string gifterStage: ""
+    property string gifterError: ""
+    // Gifter node coordinates (StepGifter inputs); both prefilled to the local
+    // dev gifter's stable peerId + address, freely editable.
+    property string gifterPeerId: M.GIFTER_PEER_ID_DEFAULT
+    property string gifterMultiaddr: M.GIFTER_MULTIADDR_DEFAULT
+    // The seed we derive the identity from and re-hand to rlnGifterRequest (it
+    // re-derives the SAME identity internally), and the card's one-shot
+    // nullifier from the verified attestation (kept for display/diagnostics).
+    property string gifterSeed: ""
+    property string gifterNullifier: ""
+    // The gifter's on-chain register_member tx hash, passed to register() so the
+    // gifted membership's detail view shows the transaction.
+    property string gifterTxHash: ""
+    // createNode + start are one-time per session; once a node answers peerInfo
+    // we skip re-creating it on a retry or a second gifted membership.
+    property bool libp2pNodeReady: false
+    // The gifter pays for registration, but the CLIENT still needs an OPEN wallet
+    // for on-chain READS: get_membership and the idempotent register both fetch
+    // accounts through the wallet's sequencer connection ("Null wallet handle"
+    // otherwise). Provisioned + opened once, unfunded, unsynced.
+    property bool gifterWalletReady: false
+    // On-chain confirmation of the gifter's registration (it submits the tx, so
+    // the PDA is Pending for a bit before get_membership can read it). Poll until
+    // it lands, then persist. Bounded so it always terminates.
+    property int giftConfirmPolls: 0
+    property int giftConfirmBudget: 40
+    property int giftConfirmMs: 6000
+    property string giftConfirmCfg: ""
+
     // Fired by finish() when the user leaves the completed wizard.
     signal completed(string commitment)
 
@@ -170,6 +211,17 @@ Item {
             regState = ""
             commitment = ""
             rateLimitMismatch = false
+        }
+        // A re-run re-offers the Welcome choice, so default back to the wallet
+        // path and clear the last gift attempt (a fresh seed/attestation next
+        // time). The libp2p node, if up, stays up.
+        registrationMode = "wallet"
+        if (gifterPhase !== "running") {
+            gifterPhase = "idle"
+            gifterStage = ""
+            gifterError = ""
+            gifterSeed = ""
+            gifterNullifier = ""
         }
     }
 
@@ -560,7 +612,13 @@ Item {
             identity_commitment: commitment,
             identity_secret_hash: secretHash
         })
-        var options = JSON.stringify({ funding_holding_account_id: holdingHex })
+        // The gifter already funded + registered this identity on-chain, so
+        // register() is idempotent here: with no funding account it detects the
+        // existing membership and just records it in the keystore (no faucet,
+        // no wallet). The wallet path passes its faucet holding as before.
+        var options = registrationMode === "gifter"
+            ? JSON.stringify({ gifter_tx_hash: gifterTxHash })
+            : JSON.stringify({ funding_holding_account_id: holdingHex })
         callRetry(M.MEMBERSHIP_MODULE, "register",
                [registryId, credential, rateLimit, options], function (r) {
             flow.secretHash = ""
@@ -624,6 +682,238 @@ Item {
         })
     }
 
+    // ---- Gifter path ---------------------------------------------------------
+    // One callback chain replacing wallet/sync/faucet: bring up a libp2p node,
+    // derive an identity from a fresh seed, capture a Keycard attestation bound
+    // to its commitment, ask the gifter to register it (the gifter pays), then
+    // hand off to the Phase E persist+confirm tail (which drives regPhase, so
+    // OnboardingView completes the wizard exactly as the wallet path does).
+    // ORDER MATTERS: the attestation must be bound to the commitment, so the
+    // identity is derived BEFORE capture.
+    function startGifter() {
+        if (gifterPhase === "running" || gifterPhase === "done")
+            return
+        // Keycard grants are clamped server-side to RATE_LIMIT_MIN regardless of
+        // the request, so ask for exactly that — otherwise the persist step sees
+        // the granted rate differ from the requested one and warns spuriously.
+        rateLimit = M.RATE_LIMIT_MIN
+        gifterPhase = "running"
+        gifterError = ""
+        gifterStage = "wallet"
+        ensureGifterWallet(function (wErr) {
+        if (wErr) { flow.failGifter(wErr); return }
+        flow.gifterStage = "node"
+        flow.ensureLibp2pNode(function (nodeErr) {
+            if (nodeErr) { flow.failGifter(nodeErr); return }
+            flow.gifterStage = "identity"
+            flow.gifterSeed = M.randomSeedHex()
+            flow.callRetry(M.RLN_MODULE, "generate_identity", [flow.gifterSeed], function (r) {
+                if (r.error) { flow.failGifter(M.errorText(r.error)); return }
+                if (!r.id_commitment || !r.id_secret_hash) {
+                    flow.failGifter("generate_identity returned no credential: " + JSON.stringify(r))
+                    return
+                }
+                flow.commitment = r.id_commitment
+                flow.secretHash = r.id_secret_hash
+                flow.captureAndRequest()
+            })
+        })
+        })
+    }
+
+    // Open a wallet for the CLIENT's on-chain reads (the gifter still pays for the
+    // registration). provision_wallet_home creates the config/home; then open an
+    // existing store or create a fresh one — NO sync, NO faucet. get_membership +
+    // the idempotent register need this or they hit "Null wallet handle".
+    function ensureGifterWallet(cb) {
+        if (gifterWalletReady) { cb(""); return }
+        flow.callRetry(M.MEMBERSHIP_MODULE, "provision_wallet_home",
+               [JSON.stringify({ sequencer_addr: M.TESTNET_SEQUENCER_ADDR })], function (r) {
+            if (r.error) { cb("Couldn't set up the wallet: " + M.errorText(r.error)); return }
+            var configPath = String(r.config_path || "")
+            var storagePath = String(r.storage_path || "")
+            if (r.storage_exists === true) {
+                flow.callRetry(M.WALLET_MODULE, "open", [configPath, storagePath], function (ro) {
+                    // A non-zero open on an already-open daemon wallet is fine for
+                    // reads; proceed either way.
+                    flow.gifterWalletReady = true
+                    cb("")
+                })
+            } else {
+                M.call(bridge, M.WALLET_MODULE, "create_new", [configPath, storagePath, flow.password], function (rc) {
+                    if (rc.error && rc.error.kind !== "empty_reply") {
+                        cb("Couldn't create the wallet: " + M.errorText(rc.error)); return
+                    }
+                    M.call(bridge, M.WALLET_MODULE, "save", [], function () {
+                        flow.gifterWalletReady = true
+                        cb("")
+                    })
+                })
+            }
+        })
+    }
+
+    function retryGifter() {
+        if (gifterPhase === "running")
+            return
+        gifterPhase = "idle"
+        startGifter()
+    }
+
+    function failGifter(msg) {
+        flow.gifterStage = ""
+        flow.gifterPhase = "error"
+        flow.gifterError = msg
+    }
+
+    // Every libp2p_module call is RELAYED through rln_gifter_module.libp2p_call
+    // — direct libp2p replies marshal to null over the QML bridge. argObj is the
+    // libp2p method's single object arg (undefined for no-arg methods); cb gets
+    // the parsed {success,value,error}.
+    function libp2pCall(method, argObj, cb, timeoutMs) {
+        if (!bridge) { cb({ error: "no bridge" }); return }
+        var args = (argObj === undefined || argObj === null) ? [] : [JSON.stringify(argObj)]
+        bridge.callModuleAsync(M.GIFTER_MODULE, "libp2p_call",
+            [JSON.stringify({ method: method, args: args })], function (raw) {
+                cb(M.parseLibp2pReply(raw))
+            }, timeoutMs === undefined ? 30000 : timeoutMs)
+    }
+
+    // Bring up a PLAIN libp2p node with createNode + start — the gifter client
+    // only needs to dial the gifter and open a stream, so no RLN/mix context is
+    // required (works against vanilla upstream libp2p_module). start's success is
+    // the gate. The FIRST libp2p_call can race libp2p_module's token registration
+    // ("auth token not recognized"/"Invalid response"); retry a few times.
+    function ensureLibp2pNode(cb) {
+        if (libp2pNodeReady) { cb(""); return }
+        flow.createNodeAttempt(0, cb)
+    }
+
+    function createNodeAttempt(attempt, cb) {
+        flow.libp2pCall("createNode", M.LIBP2P_NODE_CONFIG, function (r) {
+            var err = M.libp2pError(r)
+            if (err !== "" && err.indexOf("already") === -1) {
+                var racey = err.indexOf("token") !== -1 || err.indexOf("Invalid response") !== -1
+                          || err.indexOf("not recognized") !== -1 || err.indexOf("not connected") !== -1
+                if (attempt < 8 && racey) {
+                    var t = retryTimerComponent.createObject(flow, { interval: 700 })
+                    t.triggered.connect(function () { t.destroy(); flow.createNodeAttempt(attempt + 1, cb) })
+                    t.start()
+                    return
+                }
+                cb("Could not create the peer-to-peer node: " + err)
+                return
+            }
+            flow.libp2pCall("start", undefined, function (r2) {
+                var e2 = M.libp2pError(r2)
+                if (e2 !== "" && e2.indexOf("already") === -1) {
+                    cb("Could not start the peer-to-peer node: " + e2)
+                    return
+                }
+                flow.libp2pNodeReady = true
+                cb("")
+            })
+        })
+    }
+
+    // Capture the attestation (blocks until the card is tapped — no timeout),
+    // then dial the gifter. On grant, hand off to the persist+confirm tail.
+    function captureAndRequest() {
+        gifterStage = "capture"
+        M.call(bridge, M.CAPTURE_MODULE, "capture_attestation", [commitment], function (r) {
+            if (r.error) { flow.failGifter(M.errorText(r.error)); return }
+            if (r.verified !== true || !r.attestation_tlv) {
+                flow.failGifter("The Keycard attestation could not be verified. Is a genuine card tapped?")
+                return
+            }
+            flow.gifterNullifier = r.nullifier || ""
+            var cfg = M.registryConfigHex(flow.registryId)
+            if (cfg === "") {
+                flow.failGifter("Registry id is not logos:<ref>:<64-hex> — cannot derive the config account.")
+                return
+            }
+            flow.gifterStage = "dial"
+            var reqObj = {
+                gifterPeerId: flow.gifterPeerId.trim(),
+                gifterMultiaddr: flow.gifterMultiaddr.trim(),
+                config: cfg,
+                seed: flow.gifterSeed,
+                rate: flow.rateLimit,
+                attestation: r.attestation_tlv
+            }
+            // rln_gifter_module.request runs the whole gifter protocol over
+            // libp2p_module's generic bridge and returns a plain-String JSON
+            // (real value through the QML bridge, unlike a libp2p LogosResult).
+            // Its internal timeout is 180s (dial + auth + on-chain register);
+            // give the client a little more so we see the real error rather than
+            // a client-side cutoff.
+            M.call(bridge, M.GIFTER_MODULE, "request", [JSON.stringify(reqObj)], function (rr) {
+                if (rr.error) {
+                    // The module registers on-chain BEFORE the (best-effort) mix
+                    // identity adoption, so a real error here means nothing was
+                    // granted — auth refused, dial/timeout. Fail fast.
+                    flow.failGifter(M.gifterErrorText(rr.error))
+                    return
+                }
+                if (rr.auth_success !== true && rr.leaf_index === undefined) {
+                    flow.failGifter("The gifter did not grant a membership: " + JSON.stringify(rr))
+                    return
+                }
+                // The gifter's on-chain tx — carried into the record so the detail
+                // view shows it (the gifter submitted it on our behalf).
+                flow.gifterTxHash = rr.tx_hash || ""
+                // Granted (identity_adopted may be false — mix adoption is optional
+                // and not needed here). The PDA is Pending briefly, so poll for the
+                // on-chain confirmation, then persist to the keystore.
+                flow.confirmAndPersist(cfg)
+            }, 190000)
+        }, 0)
+    }
+
+    // The gift IS registered on-chain (rlnGifterRequest returned success), but the
+    // PDA is Pending for a bit, so poll get_membership until it lands, then
+    // persist + confirm. Stays in the running "confirm" stage (progress, not an
+    // error); times out with a clear message if it never confirms (e.g. the
+    // gifter couldn't apply the tx).
+    function confirmAndPersist(cfg) {
+        flow.gifterStage = "confirm"
+        flow.giftConfirmCfg = cfg
+        flow.giftConfirmPolls = 0
+        flow.pollGiftConfirm()
+        giftConfirmTimer.start()
+    }
+
+    function pollGiftConfirm() {
+        flow.giftConfirmPolls += 1
+        M.call(bridge, M.RLN_MODULE, "get_membership", [flow.giftConfirmCfg, commitment], function (r) {
+            if (!r.error && r.registered === true) {
+                giftConfirmTimer.stop()
+                flow.gifterStage = "persist"
+                flow.gifterPhase = "done"
+                flow.persistGifterMembership()
+                return
+            }
+            if (flow.giftConfirmPolls >= flow.giftConfirmBudget) {
+                giftConfirmTimer.stop()
+                flow.failGifter("Your membership was requested, but it didn't confirm on-chain in time. "
+                    + "The gifter may be busy — try again in a moment.")
+            }
+        })
+    }
+
+    // Persist the gifted grant + confirm it, reusing Phase E. The identity is
+    // already on-chain (the gifter registered it), so register() is idempotent
+    // and needs no funds (see submitRegistration's gifter branch); regTimer then
+    // polls it to active — driving regPhase, which OnboardingView watches to
+    // complete the wizard.
+    function persistGifterMembership() {
+        regPhase = "running"
+        regError = ""
+        regState = ""
+        rateLimitMismatch = false
+        submitRegistration()
+    }
+
     // No sync progress Timer anymore: mid-sync reads starve (and can crash
     // the module host) — chunk completions are the progress ticks.
 
@@ -639,6 +929,13 @@ Item {
         interval: flow.statePollMs
         repeat: true
         onTriggered: flow.pollRegistration()
+    }
+
+    Timer {
+        id: giftConfirmTimer
+        interval: flow.giftConfirmMs
+        repeat: true
+        onTriggered: flow.pollGiftConfirm()
     }
 
     // One-shot backoff timer for callRetry, instantiated per retry and

--- a/logos-rln-membership-ui/qml/OnboardingView.qml
+++ b/logos-rln-membership-ui/qml/OnboardingView.qml
@@ -41,7 +41,7 @@ Item {
     readonly property var nullStep: ({ ready: false, entered: function () {} })
 
     function stepItem(i) {
-        var items = [welcomeStep, passwordStep, progressStep]
+        var items = [welcomeStep, passwordStep, workStep]
         return (i >= 0 && i < items.length) ? items[i] : nullStep
     }
 
@@ -152,9 +152,22 @@ Item {
 
             StepWelcome { id: welcomeStep; flow: flow }
             StepPassword { id: passwordStep; flow: flow }
-            StepProgress {
-                id: progressStep
-                flow: flow
+            // The work step swaps on registrationMode: the wallet path's
+            // unattended bar, or the gifter path's card-tap screen. entered()
+            // dispatches to whichever is showing so the shell's kickoff is
+            // mode-agnostic; ready is unused (step 2 hides the shared CTA).
+            StackLayout {
+                id: workStep
+                currentIndex: flow.registrationMode === "gifter" ? 1 : 0
+                readonly property bool ready: true
+                function entered() {
+                    if (flow.registrationMode === "gifter")
+                        gifterStep.entered()
+                    else
+                        progressStep.entered()
+                }
+                StepProgress { id: progressStep; flow: flow }
+                StepGifter { id: gifterStep; flow: flow }
             }
         }
 
@@ -185,6 +198,20 @@ Item {
         // in-progress wallet/sync/claim/register work. restart() ("New
         // membership" from the card) resets currentStep to 0, so this
         // covers re-entry too.
+        // The alternative path: register via a gifter node + Keycard instead of
+        // a funded wallet. Sets the mode, then advances the same way Get started
+        // does (through the password/keystore step, which the gifter path still
+        // needs to persist the grant) — landing on StepGifter at the work step.
+        LinkText {
+            Layout.alignment: Qt.AlignHCenter
+            visible: view.currentStep === 0 && welcomeStep.ready
+            text: "Register with a Keycard gift"
+            onClicked: {
+                flow.registrationMode = "gifter"
+                view.advance()
+            }
+        }
+
         LinkText {
             Layout.alignment: Qt.AlignHCenter
             visible: view.currentStep === 0

--- a/logos-rln-membership-ui/qml/StepGifter.qml
+++ b/logos-rln-membership-ui/qml/StepGifter.qml
@@ -1,0 +1,159 @@
+// The gifter work screen (step 2 in "gifter" mode): point at a gifter node,
+// tap a Keycard, and let the gifter pay for the registration. Unlike the wallet
+// path's unattended bar this screen takes input (the gifter's peer id/address)
+// and a physical card tap, so it owns its own action button and progress — the
+// shell hides the shared CTA on step 2. On success the flow's regPhase reaches
+// done and OnboardingView hands off to the membership list, same as the wallet
+// path.
+import QtQuick
+import QtQuick.Layouts
+import Logos.Theme
+import Logos.Controls
+import "membership.js" as M
+
+ColumnLayout {
+    id: step
+
+    required property OnboardingFlow flow
+
+    readonly property bool busy: flow.gifterPhase === "running" || flow.regPhase === "running"
+    readonly property bool ready: flow.gifterPeerId.trim().length > 0
+                                  && flow.gifterMultiaddr.trim().length > 0
+                                  && !step.busy
+    // No auto-start: the user supplies the gifter address and taps the card.
+    function entered() {}
+
+    // Plain-language caption for the running sub-step (gifter stages first, then
+    // the shared confirmation poll once the grant lands).
+    readonly property string stageCaption:
+        flow.gifterStage === "wallet" ? "Setting up your account…"
+        : flow.gifterStage === "node" ? "Starting a peer-to-peer node…"
+        : flow.gifterStage === "identity" ? "Creating your identity…"
+        : flow.gifterStage === "capture" ? "Hold your Keycard on the reader…"
+        : flow.gifterStage === "dial" ? "Asking the gifter to register you…"
+        : (flow.gifterStage === "confirm" || flow.gifterStage === "persist"
+           || flow.regPhase === "running") ? "Confirming your membership on-chain…"
+        : "Working…"
+
+    // LogosTextField sizes its glyphs from a fixed caption token; lift them to
+    // the scaled size at 2x, as StepPassword does.
+    Component.onCompleted: {
+        var px = M.sc(Theme.typography.secondaryText)
+        peerIdField.text = step.flow.gifterPeerId
+        multiaddrField.text = step.flow.gifterMultiaddr
+        peerIdField.textInput.font.pixelSize = px
+        peerIdField.placeholderItem.font.pixelSize = px
+        multiaddrField.textInput.font.pixelSize = px
+        multiaddrField.placeholderItem.font.pixelSize = px
+    }
+
+    spacing: M.sc(Theme.spacing.medium)
+
+    LogosText {
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
+        horizontalAlignment: Text.AlignHCenter
+        font.pixelSize: M.sc(Theme.typography.titleText)
+        font.weight: Theme.typography.weightBold
+        text: "Register with a Keycard gift"
+    }
+    LogosText {
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
+        horizontalAlignment: Text.AlignHCenter
+        font.pixelSize: M.sc(Theme.typography.primaryText)
+        color: Theme.palette.textSecondary
+        text: "No wallet or tokens needed — a provider registers your membership "
+              + "when you prove you hold a genuine Keycard."
+    }
+
+    // Gifter coordinates. Hidden once the work starts so the screen becomes a
+    // clean progress view.
+    ColumnLayout {
+        visible: step.flow.gifterPhase === "idle" || step.flow.gifterPhase === "error"
+        Layout.fillWidth: true
+        spacing: M.sc(Theme.spacing.small)
+
+        LogosTextField {
+            id: peerIdField
+            Layout.fillWidth: true
+            implicitHeight: M.sc(40)
+            placeholderText: "Gifter peer id"
+            enabled: !step.busy
+            onTextChanged: step.flow.gifterPeerId = text
+        }
+        LogosTextField {
+            id: multiaddrField
+            Layout.fillWidth: true
+            implicitHeight: M.sc(40)
+            placeholderText: "Gifter address (/ip4/…/tcp/…)"
+            enabled: !step.busy
+            onTextChanged: step.flow.gifterMultiaddr = text
+        }
+    }
+
+    // The action. Owns its own button because step 2 has no shared CTA.
+    PrimaryButton {
+        visible: step.flow.gifterPhase !== "done" || step.flow.regPhase === "error"
+        Layout.fillWidth: true
+        implicitHeight: M.sc(44)
+        text: step.flow.gifterPhase === "error" ? "Try again" : "Register with Keycard"
+        enabled: step.ready
+        onClicked: step.flow.retryGifter()
+    }
+
+    // Running: a spinner + the current sub-step caption. The capture step is the
+    // one that waits on the human, so its caption names the card tap.
+    RowLayout {
+        visible: step.busy
+        Layout.alignment: Qt.AlignHCenter
+        spacing: M.sc(Theme.spacing.small)
+
+        LogosSpinner {
+            implicitWidth: M.sc(18)
+            implicitHeight: M.sc(18)
+            thickness: M.sc(2)
+            dotSize: M.sc(4)
+        }
+        LogosText {
+            text: step.stageCaption
+            color: Theme.palette.text
+            font.pixelSize: M.sc(Theme.typography.subtitleText)
+            font.weight: Theme.typography.weightMedium
+        }
+    }
+
+    // Error: plain line + the technical detail, with the retry above.
+    ColumnLayout {
+        visible: step.flow.gifterError !== "" || step.flow.regError !== ""
+        Layout.fillWidth: true
+        spacing: M.sc(Theme.spacing.tiny)
+
+        LogosText {
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            horizontalAlignment: Text.AlignHCenter
+            font.pixelSize: M.sc(Theme.typography.primaryText)
+            color: Theme.palette.error
+            text: "That didn't work — check the gifter details and your card, then try again."
+        }
+        LogosText {
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            horizontalAlignment: Text.AlignHCenter
+            color: Theme.palette.textTertiary
+            font.pixelSize: M.sc(Theme.typography.secondaryText)
+            text: step.flow.gifterError !== "" ? step.flow.gifterError : step.flow.regError
+        }
+    }
+
+    LogosText {
+        visible: step.flow.rateLimitMismatch
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
+        horizontalAlignment: Text.AlignHCenter
+        color: Theme.palette.warning
+        font.pixelSize: M.sc(Theme.typography.secondaryText)
+        text: "This identity is already registered with different settings — the existing registration wins."
+    }
+}

--- a/logos-rln-membership-ui/qml/membership.js
+++ b/logos-rln-membership-ui/qml/membership.js
@@ -8,6 +8,15 @@
 var MEMBERSHIP_MODULE = "liblogos_rln_membership_module";
 var RLN_MODULE = "liblogos_rln_module";
 var WALLET_MODULE = "logos_execution_zone";
+// The gifter path (alternative registration) additionally drives these three:
+// rln_gifter_module runs the whole gifter protocol (dial + request) over
+// libp2p_module's GENERIC protocol bridge AND relays libp2p_module calls
+// (node bring-up); keycard_capture_module does the in-process PC/SC Keycard
+// IDENTIFY capture; libp2p_module provides the libp2p node the gifter dials
+// through. None is touched by the base wallet path.
+var LIBP2P_MODULE = "libp2p_module";
+var GIFTER_MODULE = "rln_gifter_module";
+var CAPTURE_MODULE = "keycard_capture_module";
 
 // shared-faucet testnet registry (CAIP-10; descriptor under
 // <repo>/deployments/shared-faucet/) — the GUI's prefill, freely editable.
@@ -33,6 +42,52 @@ function sc(x) {
 // The deployed testnet sequencer (deployments/shared-faucet/deployment.json)
 // — prefill for provision_wallet_home's wallet_config.json.
 var TESTNET_SEQUENCER_ADDR = "https://testnet.lez.logos.co/";
+
+// Gifter path prefills — both freely editable in StepGifter. The defaults point
+// at the local dev gifter (tools/run-local-gifter.sh): a fixed node key gives it
+// a stable peerId, so this default stays valid across gifter restarts. Point
+// these elsewhere for a different gifter.
+var GIFTER_PEER_ID_DEFAULT = "16Uiu2HAm8KkYKyhBK5f8ZcSDJP947bxCqVRRbzP8DKDigqePtX2Y";
+var GIFTER_MULTIADDR_DEFAULT = "/ip4/127.0.0.1/tcp/9000";
+
+// Config for the app's OWN libp2p node — brought up only to dial the gifter
+// (the wallet path never runs libp2p). Ephemeral localhost listen port; a
+// direct protocol dial to a known peer needs no gossipsub/kad/discovery. A plain
+// object: libp2pCall JSON.stringifies it into createNode's single string arg.
+var LIBP2P_NODE_CONFIG = {
+    addrs: ["/ip4/127.0.0.1/tcp/0"],
+    transport: "tcp",
+    maxConnections: 16,
+    maxInConnections: 8,
+    maxOutConnections: 8,
+    maxConnsPerPeer: 1,
+    mountGossipsub: false,
+    mountKad: false,
+    mountServiceDiscovery: false
+};
+
+// libp2p_module's C++ methods return a StdLogosResult that marshals to `null`
+// through the QML bridge, so every libp2p call is relayed through
+// keycard_rln_module.libp2p_call (a module-to-module SDK call). It hands back the
+// real {success,value,error} as a JSON string (bridge-double-encoded like other
+// tstr replies). Parse it as-is — NOT through parseReply, whose empty-"error"
+// rule would flag a successful libp2p reply (error:"") as a failure.
+function parseLibp2pReply(payload) {
+    var v;
+    try { v = JSON.parse(payload); } catch (e) { return { error: "unparseable libp2p reply: " + payload }; }
+    if (typeof v === "string") {
+        try { v = JSON.parse(v); } catch (e) { return { error: v }; }
+    }
+    if (v === null || typeof v !== "object")
+        return { error: "unexpected libp2p reply: " + payload };
+    return v;
+}
+
+// A libp2p relay reply carries an error only when its `error` field is a
+// NON-empty string (success replies carry error:"").
+function libp2pError(r) {
+    return (r && typeof r.error === "string" && r.error !== "") ? r.error : "";
+}
 
 function mkError(kind, message) {
     return { error: { kind: kind, message: message } };
@@ -124,6 +179,29 @@ function errorText(err) {
     var msg = err && err.message ? err.message : "";
     var hint = ERROR_HINTS[kind];
     return kind + ": " + msg + (hint ? "\n" + hint : "");
+}
+
+// The gifter surfaces auth/dial failures as free-text in the error message
+// (e.g. "authentication failed: card already used"). Map the exact substrings
+// the gifter protocol emits to plain-language guidance; fall back to errorText.
+var GIFTER_ERROR_HINTS = [
+    ["card already used", "This Keycard has already claimed a membership from this provider."],
+    ["attestation CA is not trusted", "This provider doesn't recognize your Keycard."],
+    ["challenge signature does not verify", "The captured attestation didn't match this identity — re-tap your Keycard."],
+    ["attestation parse failed", "Couldn't read the card attestation — re-tap your Keycard."],
+    ["unsupported authentication_type", "This provider doesn't accept Keycard registration."],
+    ["No libp2p context", "The peer-to-peer node isn't running yet — try again in a moment."]
+];
+
+function gifterErrorText(err) {
+    var msg = (typeof err === "string") ? err
+            : (err && err.message) ? err.message
+            : (err && err.kind ? err.kind : "");
+    for (var i = 0; i < GIFTER_ERROR_HINTS.length; i++) {
+        if (msg.indexOf(GIFTER_ERROR_HINTS[i][0]) !== -1)
+            return GIFTER_ERROR_HINTS[i][1] + "\n(" + msg + ")";
+    }
+    return (typeof err === "string") ? msg : errorText(err);
 }
 
 function truncateHex(hex, head, tail) {


### PR DESCRIPTION
A "Register with a Keycard gift" path in the membership onboarding, driving the standalone rln_gifter_module + keycard_capture_module:

- wizard defaults the gifter peer id + address; opens a read-only wallet for the gifter path
- routes libp2p calls through the gifter module; requests rate-limit 100
- polls for the on-chain confirmation; on success confirm + persist (showing the gifter's tx), on error fail fast